### PR TITLE
added init function rbacadmin to fake init for pin.php #40994

### DIFF
--- a/classes/ui/player/class.LiveVotingInitialisationUI.php
+++ b/classes/ui/player/class.LiveVotingInitialisationUI.php
@@ -153,6 +153,7 @@ class LiveVotingInitialisationUI
         $this->initFilesystem();
         $this->initResourceStorage();
         $this->initGlobalScreen($GLOBALS["DIC"]);
+        $this->initRbacAdmin();
         $this->initTemplate();
         $this->initTabs();
         $this->initNavigationHistory();
@@ -188,6 +189,14 @@ class LiveVotingInitialisationUI
                 $_GET[$k] = strip_tags($_GET[$k]);
             }
         }
+    }
+
+    /**
+     * Initialize a fake rbacadmin service to satisfy the help system module
+     */
+    private function initRbacAdmin(): void
+    {
+        $this->makeGlobal('rbacadmin', new \ilRbacAdmin());
     }
 
     /**


### PR DESCRIPTION
This is the same fix for LiveVotingRW as was introduced in https://github.com/surlabs/LiveVoting/pull/11. 

My installation has the permission manager active. 