### PR TITLE
fixes mantis 45315: members can see offline LV

### DIFF
--- a/classes/class.ilObjLiveVotingAccess.php
+++ b/classes/class.ilObjLiveVotingAccess.php
@@ -33,6 +33,21 @@ class ilObjLiveVotingAccess extends ilObjectPluginAccess
         return self::hasAccess('write', $ref_id, $user_id);
     }
 
+    public function _checkAccess(string $cmd, string $permission, int $ref_id, int $obj_id, $user_id = ''): bool
+    {
+        switch ($permission) {
+            case 'visible':
+            case 'read':
+                if ($this->_isOffline($obj_id)
+                    && !self::hasAccess('write', $ref_id, $user_id)
+                ) {
+                    return false;
+                }
+        }
+        return true;
+    }
+
+
     protected static function hasAccess(string $permission, $ref_id = null, $user_id = null): bool
     {
         global $DIC;


### PR DESCRIPTION
I added the checkAccess function, so if a member has only read access they can't see an offline Livevoting