### PR TITLE
Remove unused voting history setting

### DIFF
--- a/classes/ui/voting/class.LiveVotingSettingsUI.php
+++ b/classes/ui/voting/class.LiveVotingSettingsUI.php
@@ -116,15 +116,6 @@ class LiveVotingSettingsUI
                 ));
             $formFields['vote_login_check'] = $voteLoginCheck;
 
-            $voteHistoryCheck = $DIC->ui()->factory()->input()->field()->checkbox($this->plugin->txt("voting_history"), $this->plugin->txt("voting_history_info"))
-                ->withValue($this->object->getLiveVoting()->isVotingHistory())
-                ->withAdditionalTransformation($DIC->refinery()->custom()->transformation(
-                    function ($v) {
-                        $this->object->getLiveVoting()->setVotingHistory((bool)$v);
-                    }
-                ));
-            $formFields['vote_history_check'] = $voteHistoryCheck;
-
             $showAttendeesCheck = $DIC->ui()->factory()->input()->field()->checkbox($this->plugin->txt("show_attendees"), $this->plugin->txt("show_attendees_info"))
                 ->withValue($this->object->getLiveVoting()->isShowAttendees())
                 ->withAdditionalTransformation($DIC->refinery()->custom()->transformation(

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -230,8 +230,6 @@ voting_edit#:#Bearbeiten
 voting_export#:#Export
 voting_form_title_create#:#Frage
 voting_form_title_update#:#Frage
-voting_history#:#Antworten historisieren
-voting_history_info#:#Alle Antworten werden gespeichert, auch wenn sie später geändert werden. Dadurch kann das Antwortverhalten beobachtet werden.
 voting_import#:#Import
 voting_msg_duplicated#:#Frage wurde dupliziert
 voting_msg_sorting_saved#:#Reihenfolge gespeichert

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -228,8 +228,6 @@ voting_edit#:#Edit
 voting_export#:#Export
 voting_form_title_create#:#Question
 voting_form_title_update#:#Question
-voting_history#:#Voting History
-voting_history_info#:#All answers the participants give are saved even if they change their opinion later. You can analyze the voting behaviour of your users.
 voting_import#:#Import
 voting_msg_duplicated#:#Question has been duplicated
 voting_msg_sorting_saved#:#Order saved

--- a/lang/ilias_hu.lang
+++ b/lang/ilias_hu.lang
@@ -218,8 +218,6 @@ voting_edit#:#Módosítás
 voting_export#:#Exportálás
 voting_form_title_create#:#Kérdése
 voting_form_title_update#:#Kérdése
-voting_history#:#Szavazástörténelem
-voting_history_info#:#A válaszadók összes szavazatát mentjük, akkor is, ha később azt módosítják. Így a válaszadók szavazási viselkedését is elemezheti.
 voting_import#:#Importálás
 voting_msg_duplicated#:#Kérdést sikeresen duplikálta
 voting_msg_sorting_saved#:#Sorrend mentése


### PR DESCRIPTION
## Summary
- remove unimplemented voting history checkbox from configuration form
- drop associated language strings
