### PR TITLE
Fix TextareaRTE for ILIAS 10: implement Textarea::withoutStripTags

### DIFF
--- a/classes/ui/voting/questions/Component/Input/Field/class.TextareaRTE.php
+++ b/classes/ui/voting/questions/Component/Input/Field/class.TextareaRTE.php
@@ -52,6 +52,12 @@ class TextareaRTE extends Input implements Textarea {
     protected ?int $min_limit = null;
     private array $rteSupport = [];
 
+    /**
+     * RTE content is HTML by default, so tags are never stripped. The flag exists
+     * to satisfy the Textarea interface introduced in ILIAS 10 (#7642).
+     */
+    private bool $strip_tags_from_input = false;
+
     public function __construct(string $label, ?string $byline = null)
     {
         global $DIC;
@@ -205,6 +211,17 @@ class TextareaRTE extends Input implements Textarea {
         return $this->refinery->string()->hasMinLength(1);
     }
 
+    /**
+     * Disable removing tags on user input. RTE content is HTML, so stripping is
+     * already disabled by default; this only fulfills the Textarea interface.
+     */
+    public function withoutStripTags(): Textarea
+    {
+        $clone = clone $this;
+        $clone->strip_tags_from_input = false;
+        return $clone;
+    }
+
     protected function getOperations(): Generator
     {
         if ($this->isRequired()) {
@@ -212,6 +229,10 @@ class TextareaRTE extends Input implements Textarea {
             if ($op !== null) {
                 yield $op;
             }
+        }
+
+        if ($this->strip_tags_from_input) {
+            yield $this->refinery->custom()->transformation(fn($v) => strip_tags($v));
         }
 
         yield from parent::getOperations();


### PR DESCRIPTION
## Problem

ILIAS 10 added `withoutStripTags()` to the `ILIAS\UI\Component\Input\Field\Textarea` interface (core PR #7642, "UI: Remove StripTags from Text-Inputs"). The custom `TextareaRTE` (`classes/ui/voting/questions/Component/Input/Field/class.TextareaRTE.php`) implements `Textarea` but does not implement that method. As a result the class is abstract-incomplete and PHP fatals when it is loaded on ILIAS 10:

> Class TextareaRTE contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Textarea::withoutStripTags)

## Fix

- Implement `withoutStripTags(): Textarea`.
- Add a `strip_tags_from_input` flag, honored in `getOperations()`. It defaults to **off** because RTE content is HTML and must not be stripped — preserving the existing behavior of this field.

No behavior change for existing usage; only restores ILIAS 10 loadability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
